### PR TITLE
Fix health kit date parsing logic.

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -285,8 +285,8 @@ func getFHIRDateString(fromDateComponents dateComponents: DateComponents?) -> St
     guard let dateYear = dateComponents?.year else { return "" }
     guard let dateMonth = dateComponents?.month else { return "" }
     guard let dateDay = dateComponents?.day else { return "" }
-    let dateMonthString = dateMonth > 10 ? "\(dateMonth)" : "0\(dateMonth)"
-    let dateDayString = dateDay > 10 ? "\(dateDay)" : "0\(dateDay)"
+    let dateMonthString = dateMonth > 9 ? "\(dateMonth)" : "0\(dateMonth)"
+    let dateDayString = dateDay > 9 ? "\(dateDay)" : "0\(dateDay)"
     
     return "\(dateYear)-\(dateMonthString)-\(dateDayString)"
 }


### PR DESCRIPTION
Fix health kit date parsing logic for following error.

Birthday date October 10th 2001 causes error:  
2022-09-12 12:40:53.948 [XNIO-1 task-4] WARN c.u.f.r.s.i.ExceptionHandlingInterceptor [ExceptionHandlingInterceptor.java:148] Failure during REST processing: ca.uhn.fhir.rest.server.exceptions.InvalidRequestException: HAPI-0450: Failed to parse request body as JSON resource. Error was: HAPI-1821: [element="birthDate"] Invalid attribute value "2001-010-010": Invalid date/time format: "2001-010-010": Expected character '-' at index 7 but found 0
2022-09-12 12:40:53.948 [XNIO-1 task-4] INFO fhirtest.access [LoggingInterceptor.java:160] ERROR - POST http://localhost:8080/fhir/$process-message
