### PR TITLE
update timezone from "Z" to "-00:00"

### DIFF
--- a/ios/Runner/FHIRUtils.swift
+++ b/ios/Runner/FHIRUtils.swift
@@ -62,7 +62,7 @@ class FHIRUtils {
                 if let hour = dateComponents.hour {
                     // If we have a time, we may have a timezone
                     let timezone = dateComponents.timeZone
-                    var timezoneStr = "Z";
+                    var timezoneStr = "-00:00";
                     // If timezone is set, attempt to generate a string for it
                     if let timezone = timezone, let dateObject = dateComponents.date {
                         let offset = timezone.secondsFromGMT(for: dateObject)


### PR DESCRIPTION
Update timezone logic to match HL7 v2 motion at https://confluence.hl7.org/pages/viewpage.action?pageId=31687635.

For implementations starting with V2.9
- use of the plus sign (+0000)  represents the civil time zone offset is known to be zero,
- use of the minus sign (-0000) represents UTC (without offset)

This supports medical devices that are capable of sourcing UTC but do not have reference to local time offset.  Use case is London in the winter.